### PR TITLE
Upgrade k8s image to 1.22.2 to avoid kind errors

### DIFF
--- a/test/k8s-local-cluster-test/provision-cluster
+++ b/test/k8s-local-cluster-test/provision-cluster
@@ -9,9 +9,9 @@ OVERRIDE_PATH=0
 KIND_CONFIG_FILE=$SCRIPTPATH/kind-three-node-cluster.yaml
 
 # shellcheck disable=SC2034
-K8_1_22="kindest/node:v1.22.1@sha256:7f539328bebb0483e4a91ae48fcd067619cd9fa28f4bf3b3d624858e30571a8e"
+K8_1_22="kindest/node:v1.22.2@sha256:f638a08c1f68fe2a99e724ace6df233a546eaf6713019a0b310130a4f91ebe7f"
 # shellcheck disable=SC2034
-K8_1_21="kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6"
+K8_1_21="kindest/node:v1.21.2@sha256:9d07ff05e4afefbba983fac311807b3c17a5f36e7061f6cb7e2ba756255b2be4"
 # shellcheck disable=SC2034
 K8_1_20="kindest/node:v1.20.70@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9"
 # shellcheck disable=SC2034
@@ -121,8 +121,10 @@ else
   export PATH=$TMP_DIR:$PATH
 fi
 
+# Disable spinners and color in kind output
+export TERM=dumb
 echoerr "🥑 Creating k8s cluster using \"kind\""
-retry 3 kind create cluster -q --name "$CLUSTER_NAME" --image $K8_VERSION --config "$KIND_CONFIG_FILE" --kubeconfig $TMP_DIR/kubeconfig 1>&2
+retry 3 kind create cluster --name "$CLUSTER_NAME" --image $K8_VERSION --config "$KIND_CONFIG_FILE" --kubeconfig $TMP_DIR/kubeconfig 1>&2
 
 echo "$CLUSTER_NAME" > "$TMP_DIR/clustername"
 echoerr "👍 Created k8s cluster using \"kind\""


### PR DESCRIPTION
Also allow more verbose kind output to ease debugging

Issue #, if available: #507

Description of changes: Looks like the 1.22.1 image is failing, but 1.22.2 seems to be working.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
